### PR TITLE
Update to php 8.1

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+while true; do
+    sleep 15m
+    /usr/local/bin/php -f /var/www/html/cliupdate.php
+done &
+
+exec apache2-foreground

--- a/docker/vhost.conf
+++ b/docker/vhost.conf
@@ -2,7 +2,6 @@
         ServerAdmin webmaster@localhost
         DocumentRoot /var/www/html
 
-        ErrorLog ${APACHE_LOG_DIR}/error.log
-        CustomLog ${APACHE_LOG_DIR}/access.log combined
-
+        ErrorLog /proc/self/fd/2
+        CustomLog /proc/self/fd/1 combined
 </VirtualHost>


### PR DESCRIPTION
Hi, not sure if this interests you but I made some tweaks to logging and updated to PHP 8.1

Summary of changes:
- Remove cron dependency so container will run as non-root
- Split npm pieces into an additional stage
- Add missing php extensions (tidy)
- Send logs to stdout/stderr